### PR TITLE
[#41] feat : 관리 페이지 레이아웃

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,76 +1,25 @@
 :root {
+  --swiper-theme-color: #343434 !important;
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
-    'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
-    'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
+  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono",
+    "Courier New", monospace;
 
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
 
-  --primary-glow: conic-gradient(
-    from 180deg at 50% 50%,
-    #16abff33 0deg,
-    #0885ff33 55deg,
-    #54d6ff33 120deg,
-    #0071ff33 160deg,
-    transparent 360deg
-  );
-  --secondary-glow: radial-gradient(
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0)
-  );
+  --primary-glow: conic-gradient(from 180deg at 50% 50%, #16abff33 0deg, #0885ff33 55deg, #54d6ff33 120deg, #0071ff33 160deg, transparent 360deg);
+  --secondary-glow: radial-gradient(rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
 
   --tile-start-rgb: 239, 245, 249;
   --tile-end-rgb: 228, 232, 233;
-  --tile-border: conic-gradient(
-    #00000080,
-    #00000040,
-    #00000030,
-    #00000020,
-    #00000010,
-    #00000010,
-    #00000080
-  );
+  --tile-border: conic-gradient(#00000080, #00000040, #00000030, #00000020, #00000010, #00000010, #00000080);
 
   --callout-rgb: 238, 240, 241;
   --callout-border-rgb: 172, 175, 176;
   --card-rgb: 180, 185, 188;
   --card-border-rgb: 131, 134, 135;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-
-    --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
-    --secondary-glow: linear-gradient(
-      to bottom right,
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0.3)
-    );
-
-    --tile-start-rgb: 2, 13, 46;
-    --tile-end-rgb: 2, 5, 19;
-    --tile-border: conic-gradient(
-      #ffffff80,
-      #ffffff40,
-      #ffffff30,
-      #ffffff20,
-      #ffffff10,
-      #ffffff10,
-      #ffffff80
-    );
-
-    --callout-rgb: 20, 20, 20;
-    --callout-border-rgb: 108, 108, 108;
-    --card-rgb: 100, 100, 100;
-    --card-border-rgb: 200, 200, 200;
-  }
 }
 
 * {
@@ -85,23 +34,7 @@ body {
   max-width: 100vw;
 }
 
-body {
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
-  color: rgb(var(--foreground-rgb));
-}
-
 a {
   color: inherit;
   text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import * as styles from "@/app/page.css";
+
 const Home = () => {
   return <div className={styles.container}>homee</div>;
 };

--- a/app/settings/(route)/ask/page.tsx
+++ b/app/settings/(route)/ask/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>1:1문의하기 페이지 내용~</div>;
+};
+
+export default Page;

--- a/app/settings/(route)/faq/page.tsx
+++ b/app/settings/(route)/faq/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>faq 페이지 내용~</div>;
+};
+
+export default Page;

--- a/app/settings/(route)/myprofile/page.tsx
+++ b/app/settings/(route)/myprofile/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>나의 프로필 관리 페이지 내용~</div>;
+};
+
+export default Page;

--- a/app/settings/(route)/notice/page.tsx
+++ b/app/settings/(route)/notice/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>공지사항 페이지 내용~</div>;
+};
+
+export default Page;

--- a/app/settings/(route)/receivedinvites/page.tsx
+++ b/app/settings/(route)/receivedinvites/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>초대 받은 내역 페이지 내용~</div>;
+};
+
+export default Page;

--- a/app/settings/_components/Logout/index.tsx
+++ b/app/settings/_components/Logout/index.tsx
@@ -1,0 +1,7 @@
+import * as styles from "@/app/page.css";
+
+const Logout = () => {
+  return <div className={styles.container}>요기에 로그아웃 기능</div>;
+};
+
+export default Logout;

--- a/app/settings/_components/MyProfile/index.tsx
+++ b/app/settings/_components/MyProfile/index.tsx
@@ -1,0 +1,11 @@
+const MyProfile = () => {
+  return (
+    <>
+      <div>프로필</div>
+      <div>내 닉네임</div>
+      <div>seul9085@naver.com</div>
+    </>
+  );
+};
+
+export default MyProfile;

--- a/app/settings/_components/Mypet/index.tsx
+++ b/app/settings/_components/Mypet/index.tsx
@@ -1,0 +1,29 @@
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/css";
+import "swiper/css/pagination";
+import "@/app/settings/_components/Mypet/style.css";
+import { Pagination } from "swiper/modules";
+import "@/app/globals.css";
+
+const MyPet = () => {
+  return (
+    <>
+      <Swiper
+        slidesPerView={3}
+        spaceBetween={30}
+        centeredSlides={true}
+        pagination={{
+          clickable: true,
+        }}
+        modules={[Pagination]}
+        className="mySwiper"
+      >
+        <SwiperSlide>Slide 1</SwiperSlide>
+        <SwiperSlide>Slide 2</SwiperSlide>
+        <SwiperSlide>반려동물 추가 +</SwiperSlide>
+      </Swiper>
+    </>
+  );
+};
+
+export default MyPet;

--- a/app/settings/_components/Mypet/style.css.ts
+++ b/app/settings/_components/Mypet/style.css.ts
@@ -1,0 +1,22 @@
+import { globalStyle } from "@vanilla-extract/css";
+
+globalStyle(".swiper", {
+  width: "100%",
+  height: "100%",
+});
+
+globalStyle(".swiper-slide", {
+  textAlign: "center",
+  fontSize: "18px",
+  background: "#fff",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+});
+
+globalStyle(".swiper-slide img", {
+  display: "block",
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+});

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Logout from "@/app/settings/_components/Logout";
+import MyProfile from "@/app/settings/_components/MyProfile";
+import MyPet from "@/app/settings/_components/Mypet";
+import "@/app/globals.css";
+
+const Page = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const toggleModal = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  return (
+    <>
+      <div>마이 펫 관리하기</div>
+      <MyPet />
+      <div>마이 프로필 관리하기</div>
+      <Link href="/settings/myprofile">
+        <MyProfile />
+      </Link>
+      <Link href=""></Link>
+      <Link href="settings/receivedinvites">초대 받은 내역</Link>
+      <Link href="/settings/ask">1:1 문의하기</Link>
+      <Link href="/settings/faq">faq</Link>
+      <Link href="/settings/notice">공지사항</Link>
+      <div onClick={toggleModal}>로그아웃</div>
+      {isModalOpen && <Logout />}
+    </>
+  );
+};
+
+export default Page;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "jotai": "^2.6.2",
         "next": "14.0.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "swiper": "^11.0.5"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -5904,6 +5905,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.5.tgz",
+      "integrity": "sha512-rhCwupqSyRnWrtNzWzemnBLMoyYuoDgGgspAm/8iBD3jCvAWycPLH4Z3TB0O5520DHLzMx94yUMH/B9Efpa48w==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "jotai": "^2.6.2",
     "next": "14.0.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "swiper": "^11.0.5"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## 📌 관련 이슈
- close #41 

## 💻 주요 변경 사항
- 일단 관리 페이지에서 나올 수 있는 페이지들 전체적으로 폴더 생성해봤어요!
- 그래서 각 해당하는 것들 클릭하면 그 페이지로 넘어갑니다!
- 스와이퍼 라이브러리 사용해서 펫 관리 카드 만들려고 합니당
- 아직 디자인이 완성된 게 아니라 디자인을 아예 안먹혔는데 레이아웃 정도는 그래도 해놓는 게 좋을 거 같아서 하려구요!

## 📸 스크린샷
<img width="301" alt="스크린샷 2024-01-25 오전 2 30 26" src="https://github.com/princess-team/FE-pet/assets/72639353/8e9d8ef5-32a1-4d4f-889c-7f3e69feef91">

## 📣 기타 문의(선택)
- 
